### PR TITLE
Fixing GPG

### DIFF
--- a/src/git/config.rs
+++ b/src/git/config.rs
@@ -33,6 +33,7 @@ impl GitConfig {
     /// until there is no more parent
     pub fn from_directory(path: &Path) -> Result<GitConfig, ()> {
         let file = path.join(".gitconfig");
+        println!("{:?}", file);
         let file = File::open(file);
         match file {
             Ok(mut file) => {


### PR DESCRIPTION
# Context

test command does not work because it removes signatures. This MR call `git commit --amend --no-edit` to resign the commit with gpg