### PR TITLE
git: keep note when rebasing

### DIFF
--- a/src/git/git.rs
+++ b/src/git/git.rs
@@ -360,10 +360,19 @@ impl Git {
                     let author = commit.author();
                     let committer = commit.committer();
 
-                    let _commit = rebase
+                    let note = self.repository.find_note(None, commit_id).ok();
+
+                    let commit = rebase
                         .commit(Some(&author), &committer, None)
                         .expect("Failed to commit during rebase");
 
+                    if let Some(note) = note {
+                        if let Some(note) = note.message() {
+                            self.repository
+                                .note(&author, &committer, None, commit, note, true)
+                                .expect("should be able to set the note during rebase");
+                        }
+                    }
                     // I don't like this solution...
                     // TODO: remove this ugly things...
                     let _ = Command::new("git")


### PR DESCRIPTION
# Context

Test command is removing note... Because it creates a new commit. Let's fix it.