### PR TITLE
git: remove ueseless log

### DIFF
--- a/src/git/config.rs
+++ b/src/git/config.rs
@@ -26,7 +26,6 @@ impl GitConfig {
     /// until there is no more parent
     pub fn from_directory(path: &Path) -> Result<GitConfig, ()> {
         let file = path.join(".gitconfig");
-        println!("{:?}", file);
         let file = File::open(file);
         match file {
             Ok(mut file) => {


### PR DESCRIPTION
# Context

A previous MR introduced too many logs, it should be removed