### PR TITLE
git: repository and signature can be private

### DIFF
--- a/src/git/git.rs
+++ b/src/git/git.rs
@@ -5,8 +5,8 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::{path::Path, process::Command};
 
 pub struct Git {
-    pub repository: Repository,
-    pub signature: Signature<'static>,
+    repository: Repository,
+    signature: Signature<'static>,
     config: GitConfig,
     auth: GitAuthenticator,
 }


### PR DESCRIPTION
Some field in a git data structure can be (and should be) private