### PR TITLE
git-config: check the value of rewriteRef

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,2 @@
 pub mod push;
 pub mod show;
-
-pub trait Execute {
-    fn execute(&self) -> Result<(), ()>;
-}

--- a/src/commands/push.rs
+++ b/src/commands/push.rs
@@ -5,8 +5,6 @@ use crate::{
 };
 use clap::Args;
 
-use super::Execute;
-
 #[derive(Debug, Args)]
 pub struct Push {}
 
@@ -23,8 +21,8 @@ const COMMENTS: &str = r#"
 # It's not a rebase, you can't edit commits nor reorder them
 "#;
 
-impl Execute for Push {
-    fn execute(&self) -> Result<(), ()> {
+impl Push {
+    pub fn execute(&self) -> Result<(), ()> {
         let git = Git::open(".");
 
         let commits = git.list_commits();

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -2,8 +2,6 @@ use clap::Args;
 
 use crate::{git::Git, parser::commits_to_string};
 
-use super::Execute;
-
 #[derive(Debug, Args)]
 pub struct Show {}
 
@@ -11,8 +9,8 @@ const COMMENTS: &str = r#"
 # Only display the state of the branches
 "#;
 
-impl Execute for Show {
-    fn execute(&self) -> Result<(), ()> {
+impl Show {
+    pub fn execute(&self) -> Result<(), ()> {
         let git = Git::open(".");
         let commits = git.list_commits();
         let output = commits_to_string(commits);

--- a/src/git/config.rs
+++ b/src/git/config.rs
@@ -35,6 +35,15 @@ impl GitConfig {
             .get_string("core.editor")
             .map_err(|_| println!("editor not found in configuration"))?;
 
+        // Force rewriteRef = "refs/notes/commits" to exist
+        let rewrite_ref = config
+            .get_string("notes.rewriteRef")
+            .map_err(|_| println!("editor not found in configuration"))?;
+        if rewrite_ref != "refs/notes/commits" {
+            println!("rewriteRef should be set to \"refs/notes/commits\"");
+            return Err(());
+        }
+
         Ok(Self {
             user: User { email, name },
             core: Core { editor },

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ use clap::Parser;
 use clap::Subcommand;
 use commands::push::Push;
 use commands::show::Show;
-use commands::Execute;
 
 mod commands;
 mod core;


### PR DESCRIPTION
# Context

To use this tool you need to set `notes.rewriteRef` to `refs/notes/commits`. This MR enforce the check of this value when running `yggit`