### PR TITLE
show: print output instead of passing to editor

### DIFF
--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -5,21 +5,11 @@ use crate::{git::Git, parser::commits_to_string};
 #[derive(Debug, Args)]
 pub struct Show {}
 
-const COMMENTS: &str = r#"
-# Only display the state of the branches
-"#;
-
 impl Show {
     pub fn execute(&self, git: Git) -> Result<(), ()> {
         let commits = git.list_commits();
         let output = commits_to_string(commits);
-
-        let file_path = "/tmp/yggit";
-        let output = format!("{}\n{}", output, COMMENTS);
-        std::fs::write(file_path, output).map_err(|_| println!("cannot write file to disk"))?;
-
-        git.edit_file(file_path)?;
-
+        println!("{}", output.trim());
         Ok(())
     }
 }


### PR DESCRIPTION
Hello my friend!

Unless I'm missing something, passing to editor isn't needed here. This change simply prints the commits to stdout.