### PR TITLE
Use $EDITOR from env

### DIFF
--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -5,21 +5,11 @@ use crate::{git::Git, parser::commits_to_string};
 #[derive(Debug, Args)]
 pub struct Show {}
 
-const COMMENTS: &str = r#"
-# Only display the state of the branches
-"#;
-
 impl Show {
     pub fn execute(&self, git: Git) -> Result<(), ()> {
         let commits = git.list_commits();
         let output = commits_to_string(commits);
-
-        let file_path = "/tmp/yggit";
-        let output = format!("{}\n{}", output, COMMENTS);
-        std::fs::write(file_path, output).map_err(|_| println!("cannot write file to disk"))?;
-
-        git.edit_file(file_path)?;
-
+        println!("{}", output.trim());
         Ok(())
     }
 }

--- a/src/git/config.rs
+++ b/src/git/config.rs
@@ -38,9 +38,12 @@ impl GitConfig {
             .get_string("user.name")
             .map_err(|_| println!("name not found in configuration"))?;
 
-        let editor = config
-            .get_string("core.editor")
-            .map_err(|_| println!("editor not found in configuration"))?;
+        let editor = (match config.get_string("core.editor") {
+            Ok(editor) => Ok(editor),
+            Err(_) => {
+                std::env::var("EDITOR").map_err(|_| println!("editor not found in configuration"))
+            }
+        })?;
 
         // Force rewriteRef = "refs/notes/commits" to exist
         let rewrite_ref = config


### PR DESCRIPTION
When `config.editor` is absent, I think it makes sense to use $EDITOR, which is what Git itself does.

Depends on #30 for no reason other than to try out yggit!