### PR TITLE
CLI: add version

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,8 @@ mod git;
 mod parser;
 
 #[derive(Debug, Parser)] // requires `derive` feature
-#[command(name = "git")]
-#[command(about = "A fictional versioning CLI", long_about = None)]
+#[command(name = "yggit")]
+#[command(version, about = "Git project manager", long_about = None)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,


### PR DESCRIPTION
# Context

I was struggling knowing what was the version of yggit was running when setting up crates.io

This MR adds a `--version` argument to know the version of yggit